### PR TITLE
为releaseLogFile函数读取文件时添加errors='ignore'，以排除可能意外出现的log文件内容错误

### DIFF
--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -177,7 +177,7 @@ def releaseLogFile(logName):
     dataLogFile = '%s%s/%s.olivadicelog' % (dataPath, dataLogPath, logName)
     dataLogFile_1 = '%s%s/%s.trpglog' % (dataPath, dataLogPath, logName)
     tmp_dataLogFile = None
-    with open(dataLogFile, 'r+', encoding = 'utf-8') as dataLogFile_f:
+    with open(dataLogFile, 'r+', encoding = 'utf-8' , errors='ignore' ) as dataLogFile_f:
         tmp_dataLogFile = dataLogFile_f.read()
     if tmp_dataLogFile != None:
         tmp_dataLogFile = tmp_dataLogFile.strip('\n')


### PR DESCRIPTION
.olivadicelog文件保存时偶尔会出现json串缺失/出现非utf-8编码的问题，导致releaseLogFile函数处理出错。此处为releaseLogFile函数读取文件时添加errors='ignore'，以排除可能意外出现的log文件内容错误（比较粗暴的解法）