### PR TITLE
增加日志条数记录，若消息撤回则导出时不显示，新增命令功能

### DIFF
--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -136,7 +136,6 @@ def loggerEntryLazyReply(self_arg):
     except Exception as e:
         traceback.print_exc()
 
-
 def add_logger_func(target_func):
     @wraps(target_func)
     def logger_func(*arg, **kwargs):
@@ -153,6 +152,22 @@ def is_valid_log_name(name):
         return False
     
     return True
+
+def get_log_lines(log_name):
+    check_and_process_compatibility()
+    dataPath = OlivaDiceLogger.data.dataPath
+    dataLogPath = OlivaDiceLogger.data.dataLogPath
+    dataLogFile = '%s%s/%s.olivadicelog' % (dataPath, dataLogPath, log_name)
+    
+    if not os.path.exists(dataLogFile):
+        return 0
+    
+    try:
+        with open(dataLogFile, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+            return len(lines)
+    except:
+        return 0
 
 def check_log_file_exists(log_name):
     check_and_process_compatibility()

--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -136,6 +136,79 @@ def loggerEntryLazyReply(self_arg):
     except Exception as e:
         traceback.print_exc()
 
+# 记录日志时撤回添加撤回标记
+def handle_message_recall(event):
+    try:
+        message_id = event.data.message_id
+        group_id = event.data.group_id
+        botHash = event.bot_info.hash
+        try:
+            import OlivOSOnebotV11
+            host_id = OlivOSOnebotV11.eventRouter.getHostIdDict(
+                    botHash=botHash,
+                    groupId=group_id
+                )
+        except Exception as e:
+            host_id = None
+        tmp_hagID = f"{host_id}|{group_id}" if host_id else str(group_id)
+        
+        if not OlivaDiceCore.userConfig.getUserConfigByKey(
+            userId=tmp_hagID,
+            userType='group',
+            platform=event.platform['platform'],
+            userConfigKey='logEnable',
+            botHash=event.bot_info.hash
+        ):
+            return
+
+        log_name = OlivaDiceCore.userConfig.getUserConfigByKey(
+            userId=tmp_hagID,
+            userType='group',
+            platform=event.platform['platform'],
+            userConfigKey='logActiveName',
+            botHash=event.bot_info.hash
+        )
+        if not log_name:
+            return
+
+        log_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+            userId=tmp_hagID,
+            userType='group',
+            platform=event.platform['platform'],
+            userConfigKey='logNameDict',
+            botHash=event.bot_info.hash
+        ) or {}
+        log_uuid = log_name_dict.get(log_name, str(uuid.uuid4()))
+        tmp_logName = f'log_{log_uuid}_{log_name}'
+        log_file = f'{OlivaDiceLogger.data.dataPath}{OlivaDiceLogger.data.dataLogPath}/{tmp_logName}.olivadicelog'
+
+        if not os.path.exists(log_file):
+            return
+
+        if log_file not in gLoggerIOLockMap:
+            gLoggerIOLockMap[log_file] = threading.Lock()
+        
+        with gLoggerIOLockMap[log_file]:
+            updated_lines = []
+            modified = False
+            with open(log_file, 'r', encoding='utf-8') as f:
+                for line in f:
+                    try:
+                        log_entry = json.loads(line.strip())
+                        if str(log_entry.get('message_id')) == str(message_id):
+                            log_entry['deleted'] = True
+                            modified = True
+                        updated_lines.append(json.dumps(log_entry, ensure_ascii=False) + '\n')
+                    except json.JSONDecodeError:
+                        continue
+
+            if modified:
+                with open(log_file, 'w', encoding='utf-8') as f:
+                    f.writelines(updated_lines)
+
+    except Exception as e:
+        traceback.print_exc()
+
 def add_logger_func(target_func):
     @wraps(target_func)
     def logger_func(*arg, **kwargs):
@@ -210,9 +283,13 @@ def loggerEntry(event, funcType, sender, dectData, message):
             userConfigKey = 'logEnable',
             botHash = event.bot_info.hash
         ):
+            message_id = event.data.message_id
+                
             log_dict = {
                 'time': int(time.mktime(time.localtime())),
                 'type': funcType,
+                'message_id': message_id,
+                'deleted': False,
                 'dect': {
                     'host_id': host_id,
                     'group_id': group_id,
@@ -270,6 +347,9 @@ def releaseLogFile(logName):
             except:
                 tmp_dataLog_json = None
             if tmp_dataLog_json != None:
+                # 跳过增加删除标记的消息
+                if tmp_dataLog_json.get('deleted', False):
+                    continue
                 res_logFile_str += '%s(%s) %s\n%s\n' % (
                     str(tmp_dataLog_json['sender']['name']),
                     str(tmp_dataLog_json['sender']['id']),

--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -334,31 +334,36 @@ def releaseLogFile(logName):
         return False
         
     tmp_dataLogFile = None
-    with open(dataLogFile, 'r+', encoding = 'utf-8' , errors='ignore' ) as dataLogFile_f:
-        tmp_dataLogFile = dataLogFile_f.read()
-    if tmp_dataLogFile != None:
-        tmp_dataLogFile = tmp_dataLogFile.strip('\n')
-        tmp_dataLogFile_list = tmp_dataLogFile.split('\n')
-        res_logFile_str = ''
-        for tmp_dataLogFile_list_this in tmp_dataLogFile_list:
-            tmp_dataLog_json = None
-            try:
-                tmp_dataLog_json = json.loads(tmp_dataLogFile_list_this)
-            except:
+    try:
+        with open(dataLogFile, 'r+', encoding = 'utf-8' , errors='ignore' ) as dataLogFile_f:
+            tmp_dataLogFile = dataLogFile_f.read()
+        
+        if tmp_dataLogFile != None:
+            tmp_dataLogFile = tmp_dataLogFile.strip('\n')
+            tmp_dataLogFile_list = tmp_dataLogFile.split('\n')
+            res_logFile_str = ''
+            for tmp_dataLogFile_list_this in tmp_dataLogFile_list:
                 tmp_dataLog_json = None
-            if tmp_dataLog_json != None:
-                # 跳过增加删除标记的消息
-                if tmp_dataLog_json.get('deleted', False):
-                    continue
-                res_logFile_str += '%s(%s) %s\n%s\n' % (
-                    str(tmp_dataLog_json['sender']['name']),
-                    str(tmp_dataLog_json['sender']['id']),
-                    str(time.strftime('%H:%M:%S', time.localtime(tmp_dataLog_json['time']))),
-                    str(tmp_dataLog_json['message'])
-                )
-        with open(dataLogFile_1, 'w+', encoding = 'utf-8') as dataLogFile_f:
-            dataLogFile_f.write(res_logFile_str)
-        return True
+                try:
+                    tmp_dataLog_json = json.loads(tmp_dataLogFile_list_this)
+                except:
+                    tmp_dataLog_json = None
+                if tmp_dataLog_json != None:
+                    # 跳过增加删除标记的消息
+                    if tmp_dataLog_json.get('deleted', False):
+                        continue
+                    res_logFile_str += '%s(%s) %s\n%s\n' % (
+                        str(tmp_dataLog_json['sender']['name']),
+                        str(tmp_dataLog_json['sender']['id']),
+                        str(time.strftime('%H:%M:%S', time.localtime(tmp_dataLog_json['time']))),
+                        str(tmp_dataLog_json['message'])
+                    )
+            with open(dataLogFile_1, 'w+', encoding = 'utf-8') as dataLogFile_f:
+                dataLogFile_f.write(res_logFile_str)
+            return True
+    except Exception as e:
+        traceback.print_exc()
+        return False
     return False
 
 def uploadLogFile(logName):

--- a/OlivaDiceLogger/main.py
+++ b/OlivaDiceLogger/main.py
@@ -32,6 +32,9 @@ class Event(object):
 
     def group_message(plugin_event, Proc):
         OlivaDiceLogger.msgReply.unity_reply(plugin_event, Proc)
+        
+    def group_message_recall(plugin_event, Proc):
+        OlivaDiceLogger.logger.handle_message_recall(plugin_event)
 
     def poke(plugin_event, Proc):
         pass

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -23,10 +23,10 @@ dictStrCustomDict = {}
 dictStrCustom = {
     'strLoggerLogOn': '开始记录日志 [{tLogName}]',
     'strLoggerLogAlreadyOn': '已经正在记录日志 [{tLogName}]',
-    'strLoggerLogContinue': '继续记录日志 [{tLogName}]',
-    'strLoggerLogOff': '暂停记录日志 [{tLogName}]',
+    'strLoggerLogContinue': '继续记录日志 [{tLogName}] (当前已记录 {tLogLines} 行)',
+    'strLoggerLogOff': '暂停记录日志 [{tLogName}] (当前已记录 {tLogLines} 行)',
     'strLoggerLogAlreadyOff': '没有正在进行的日志',
-    'strLoggerLogEnd': '结束记录日志 [{tLogName}]',
+    'strLoggerLogEnd': '结束记录日志 [{tLogName}] (当前已记录 {tLogLines} 行)',
     'strLoggerLogAlreadyEnd': '没有正在进行的日志',
     'strLoggerLogSave': '日志 [{tLogName}] (UUID: {tLogUUID}) 已保存',
     'strLoggerLogUrl': '日志已上传，请在[ {tLogUrl} ]提取日志',

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -34,7 +34,13 @@ dictStrCustom = {
     'strLoggerLogListEmpty': '本群暂无日志',
     'strLoggerLogNotFound': '未找到日志 [{tLogName}]',
     'strLoggerLogSwitch': '已切换到日志 [{tLogName}]',
-    'strLoggerLogInvalidName': '日志名称 [{tLogName}] 不合法'
+    'strLoggerLogInvalidName': '日志名称 [{tLogName}] 不合法',
+    'strLoggerLogStop': '已强制停止日志 [{tLogName}] (UUID: {tLogUUID}) (当前已记录 {tLogLines} 行)',
+    'strLoggerLogStopError': '已强制停止日志 [{tLogName}] (UUID: {tLogUUID}) (日志已损坏)',
+    'strLoggerLogUploadNoName': '请指定要上传的日志的UUID',
+    'strLoggerLogFileNotFound': '未找到[{tLogUUID}]对应的日志文件',
+    'strLoggerLogUploadSuccess': '日志 [{tLogName}](UUID: {tLogUUID}) 重新上传成功，请在[ {tLogUrl} ]提取日志',
+    'strLoggerLogUploadFailed': '日志 [{tLogName}](UUID: {tLogUUID}) 重新上传失败，请稍后再试'
 }
 
 dictStrConst = {
@@ -54,6 +60,8 @@ dictHelpDocTemp = {
 .log off [名字] 暂停记录指定或当前日志
 .log end [名字] 完成记录并发送日志文件
 .log list 查看本群日志列表
+.log stop [名字] 强制停止日志不上传
+.log upload [UUID] 手动上传指定UUID的日志(必须为已经end/stop的日志)
 若不带名字则默认名字为default
 日志上传存在失败可能，届时请联系后台管理索取''',
 

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -241,6 +241,10 @@ def unity_reply(plugin_event, Proc):
                     dictTValue['tLogName'] = log_name
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogOn'], dictTValue)
                 else:
+                    tmp_log_uuid = log_name_dict.get(log_name, str(uuid.uuid4()))
+                    tmp_logName = f'log_{tmp_log_uuid}_{log_name}'
+                    log_lines = OlivaDiceLogger.logger.get_log_lines(tmp_logName)
+                    dictTValue['tLogLines'] = str(log_lines)
                     dictTValue['tLogName'] = log_name
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogContinue'], dictTValue)
 
@@ -275,7 +279,15 @@ def unity_reply(plugin_event, Proc):
             elif isMatchWordStart(tmp_reast_str, 'off'):
                 tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'off')
                 tmp_reast_str = skipSpaceStart(tmp_reast_str)
-
+                
+                log_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId = tmp_hagID,
+                    userType = 'group',
+                    platform = plugin_event.platform['platform'],
+                    userConfigKey = 'logNameDict',
+                    botHash = plugin_event.bot_info.hash
+                ) or {}
+                
                 # 优先使用当前记录日志
                 log_name = OlivaDiceCore.userConfig.getUserConfigByKey(
                     userId = tmp_hagID,
@@ -310,6 +322,10 @@ def unity_reply(plugin_event, Proc):
                             userType = 'group',
                             platform = plugin_event.platform['platform']
                         )
+                        tmp_log_uuid = log_name_dict.get(log_name, str(uuid.uuid4()))
+                        tmp_logName = f'log_{tmp_log_uuid}_{log_name}'
+                        log_lines = OlivaDiceLogger.logger.get_log_lines(tmp_logName)
+                        dictTValue['tLogLines'] = str(log_lines)
                         dictTValue['tLogName'] = log_name
                         tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogOff'], dictTValue)
                     else:
@@ -370,6 +386,8 @@ def unity_reply(plugin_event, Proc):
 
                 tmp_log_uuid = log_name_dict.get(log_name, str(uuid.uuid4()))
                 tmp_logName = f'log_{tmp_log_uuid}_{log_name}'
+                log_lines = OlivaDiceLogger.logger.get_log_lines(tmp_logName)
+                dictTValue['tLogLines'] = str(log_lines)
 
                 active_log_name = OlivaDiceCore.userConfig.getUserConfigByKey(
                     userId = tmp_hagID,

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -569,7 +569,215 @@ def unity_reply(plugin_event, Proc):
 
                 replyMsg(plugin_event, tmp_reply_str)
                 return
+            
+            elif isMatchWordStart(tmp_reast_str, 'stop'):
+                tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'stop')
+                tmp_reast_str = skipSpaceStart(tmp_reast_str)
+                
+                log_name = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId = tmp_hagID,
+                    userType = 'group',
+                    platform = plugin_event.platform['platform'],
+                    userConfigKey = 'logActiveName',
+                    botHash = plugin_event.bot_info.hash
+                )
+            
+                if tmp_reast_str.strip() != '':
+                    log_name = tmp_reast_str.strip()
+            
+                if log_name is None:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogAlreadyEnd'], dictTValue)
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+            
+                log_name_list = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId = tmp_hagID,
+                    userType = 'group',
+                    platform = plugin_event.platform['platform'],
+                    userConfigKey = 'logNameList',
+                    botHash = plugin_event.bot_info.hash
+                ) or []
+            
+                if log_name not in log_name_list:
+                    dictTValue['tLogName'] = log_name
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogNotFound'], dictTValue)
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+            
+                log_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId = tmp_hagID,
+                    userType = 'group',
+                    platform = plugin_event.platform['platform'],
+                    userConfigKey = 'logNameDict',
+                    botHash = plugin_event.bot_info.hash
+                ) or {}
+            
+                tmp_log_uuid = log_name_dict.get(log_name, str(uuid.uuid4()))
+                tmp_logName = f'log_{tmp_log_uuid}_{log_name}'
 
+                # 检查日志文件是否存在，若不存在则创建空文件
+                dataPath = OlivaDiceLogger.data.dataPath
+                dataLogPath = OlivaDiceLogger.data.dataLogPath
+                dataLogFile = f'{dataPath}{dataLogPath}/{tmp_logName}.olivadicelog'
+                log_error = False
+
+                if os.path.exists(dataLogFile):
+                    try:
+                        with open(dataLogFile, 'r', encoding='utf-8') as f:
+                            for line in f:
+                                line = line.strip()
+                                if line:
+                                    try:
+                                        json.loads(line)
+                                    except json.JSONDecodeError:
+                                        log_error = True
+                                        break
+                                    
+                        # 如果检测到错误，重命名原文件并创建新文件
+                        if log_error:
+                            error_log_file = f'{dataPath}{dataLogPath}/error_{tmp_logName}.txt'
+                            try:
+                                os.rename(dataLogFile, error_log_file)
+                                with open(dataLogFile, 'w', encoding='utf-8') as f:
+                                    f.write('{}')
+                            except Exception as e:
+                                traceback.print_exc()
+                                log_error = True
+
+                    except Exception as e:
+                        traceback.print_exc()
+                        log_error = True
+                else:
+                    try:
+                        with open(dataLogFile, 'w', encoding='utf-8') as f:
+                            f.write('{}')
+                    except Exception as e:
+                        traceback.print_exc()
+                        log_error = True
+
+                log_lines = OlivaDiceLogger.logger.get_log_lines(tmp_logName)
+                dictTValue['tLogLines'] = str(log_lines)
+                dictTValue['tLogUUID'] = tmp_log_uuid
+            
+                active_log_name = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId = tmp_hagID,
+                    userType = 'group',
+                    platform = plugin_event.platform['platform'],
+                    userConfigKey = 'logActiveName',
+                    botHash = plugin_event.bot_info.hash
+                )
+            
+                if active_log_name == log_name:
+                    OlivaDiceCore.userConfig.setUserConfigByKey(
+                        userConfigKey = 'logEnable',
+                        userConfigValue = False,
+                        botHash = plugin_event.bot_info.hash,
+                        userId = tmp_hagID,
+                        userType = 'group',
+                        platform = plugin_event.platform['platform']
+                    )
+                    OlivaDiceCore.userConfig.setUserConfigByKey(
+                        userConfigKey = 'logActiveName',
+                        userConfigValue = None,
+                        botHash = plugin_event.bot_info.hash,
+                        userId = tmp_hagID,
+                        userType = 'group',
+                        platform = plugin_event.platform['platform']
+                    )
+            
+                # 强制生成.trpglog文件
+                success = OlivaDiceLogger.logger.releaseLogFile(tmp_logName)
+                if not success:
+                    # 如果生成失败，创建一个文件显示日志已损坏
+                    dataLogFile_1 = f'{dataPath}{dataLogPath}/{tmp_logName}.trpglog'
+                    with open(dataLogFile_1, 'w', encoding='utf-8') as f:
+                        f.write('日志已损坏')
+            
+                dictTValue['tLogName'] = log_name
+                if not log_error:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogStop'], dictTValue)
+                else:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogStopError'], dictTValue)
+
+                replyMsg(plugin_event, tmp_reply_str)
+            
+                if log_name in log_name_list:
+                    log_name_list.remove(log_name)
+                    OlivaDiceCore.userConfig.setUserConfigByKey(
+                        userConfigKey = 'logNameList',
+                        userConfigValue = log_name_list,
+                        botHash = plugin_event.bot_info.hash,
+                        userId = tmp_hagID,
+                        userType = 'group',
+                        platform = plugin_event.platform['platform']
+                    )
+                    
+                    if log_name in log_name_dict:
+                        del log_name_dict[log_name]
+                        OlivaDiceCore.userConfig.setUserConfigByKey(
+                            userConfigKey = 'logNameDict',
+                            userConfigValue = log_name_dict,
+                            botHash = plugin_event.bot_info.hash,
+                            userId = tmp_hagID,
+                            userType = 'group',
+                            platform = plugin_event.platform['platform']
+                        )
+            
+                OlivaDiceCore.userConfig.writeUserConfigByUserHash(
+                    userHash = OlivaDiceCore.userConfig.getUserHash(
+                        userId = tmp_hagID,
+                        userType = 'group',
+                        platform = plugin_event.platform['platform']
+                    )
+                )
+                return
+
+            elif isMatchWordStart(tmp_reast_str, 'upload'):
+                tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'upload')
+                tmp_reast_str = skipSpaceStart(tmp_reast_str)
+
+                if not tmp_reast_str.strip():
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogUploadNoName'], dictTValue)
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+
+                log_uuid = tmp_reast_str.strip()
+                log_name = None
+                
+                dataPath = OlivaDiceLogger.data.dataPath
+                dataLogPath = OlivaDiceLogger.data.dataLogPath
+                log_files = [f for f in os.listdir(f'{dataPath}{dataLogPath}') 
+                           if f.startswith(f'log_{log_uuid}_') and f.endswith('.trpglog')]
+                
+                if log_files:
+                    # 从文件名中提取log_name
+                    log_name = log_files[0].replace(f'log_{log_uuid}_', '').replace('.trpglog', '')
+                
+                if not log_name:
+                    dictTValue['tLogUUID'] = log_uuid
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogFileNotFound'], dictTValue)
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+
+                tmp_logName = f'log_{log_uuid}_{log_name}'
+                dataPath = OlivaDiceLogger.data.dataPath
+                dataLogPath = OlivaDiceLogger.data.dataLogPath
+                dataLogFile_1 = f'{dataPath}{dataLogPath}/{tmp_logName}.trpglog'
+
+                try:
+                    OlivaDiceLogger.logger.uploadLogFile(tmp_logName)
+                    dictTValue['tLogName'] = log_name
+                    dictTValue['tLogUUID'] = log_uuid
+                    dictTValue['tLogUrl'] = f'{OlivaDiceLogger.data.dataLogPainterUrl}{tmp_logName}'
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogUploadSuccess'], dictTValue)
+                    replyMsg(plugin_event, tmp_reply_str)
+                except Exception as e:
+                    dictTValue['tLogName'] = log_name
+                    dictTValue['tLogUUID'] = log_uuid
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(dictStrCustom['strLoggerLogUploadFailed'], dictTValue)
+                    replyMsg(plugin_event, tmp_reply_str)
+                    traceback.print_exc()
+                return
             else:
                 replyMsgLazyHelpByEvent(plugin_event, 'log')
             return


### PR DESCRIPTION
1：增加日志条数记录{tLogLines}
2：若消息撤回则导出时不显示（兼容同群多日志时期的旧日志，不兼容更早之前的日志）（实际上是增加了一个delete标记，也就是说如果想要也可以翻olvadicelog文件来找到对应的消息，并不会完全删除）
3：新增命令 .log stop 和 .log upload，log stop可以强制停止当前log或者指定log而不上传，拥有极其完善的异常处理能力；log upload可以通过uuid来重新上传对应的log（前提是log已经end/stop了）