### PR TITLE
feat: 新增跨平台日志续接功能，qqGuildv2支持markdown输出

### DIFF
--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.32",
-    "svn" : 40,
+    "version" : "3.0.33",
+    "svn" : 41,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.35",
-    "svn" : 43,
+    "version" : "3.0.36",
+    "svn" : 44,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.33",
-    "svn" : 41,
+    "version" : "3.0.34",
+    "svn" : 42,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.34",
-    "svn" : 42,
+    "version" : "3.0.35",
+    "svn" : 43,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.35'
-OlivaDiceLogger_svn = 43
+OlivaDiceLogger_ver = '3.0.36'
+OlivaDiceLogger_svn = 44
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'
@@ -27,5 +27,5 @@ dataLogUpload = 'http://api.dice.center/dicelogger/'
 dataLogPainterUrl = 'https://logrender.dice.center/#2-'
 
 # 跨平台续接码（纯内存，不落盘）
-# 结构: {uuid_str: {'code': 'A3F9K2', 'time': 1721448000.0}}
+# 结构: {uuid_str: {'code': 'A3F9K2', 'time': 1721448000.0, 'old_group_hash': 'md5hex'}}
 dictContinueCode = {}

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.34'
-OlivaDiceLogger_svn = 42
+OlivaDiceLogger_ver = '3.0.35'
+OlivaDiceLogger_svn = 43
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.32'
-OlivaDiceLogger_svn = 40
+OlivaDiceLogger_ver = '3.0.33'
+OlivaDiceLogger_svn = 41
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'
@@ -25,3 +25,7 @@ dataCompatibilityFlagFile = 'compatibility_done'
 
 dataLogUpload = 'http://api.dice.center/dicelogger/'
 dataLogPainterUrl = 'https://logrender.dice.center/#2-'
+
+# 跨平台续接码（纯内存，不落盘）
+# 结构: {uuid_str: {'code': 'A3F9K2', 'time': 1721448000.0}}
+dictContinueCode = {}

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.33'
-OlivaDiceLogger_svn = 41
+OlivaDiceLogger_ver = '3.0.34'
+OlivaDiceLogger_svn = 42
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -22,6 +22,7 @@ import uuid
 import re
 import json
 import os
+import glob
 import traceback
 import threading
 import requests as req
@@ -44,8 +45,6 @@ def check_and_process_compatibility():
     migrate_database_config()
     log_dir = f'{dataPath}{dataLogPath}'
     if os.path.exists(log_dir):
-        import glob
-
         for ext in ['.olivadicelog', '.trpglog', '_temp.trpglog']:
             pattern = os.path.join(log_dir, f'*{ext}')
             for filepath in glob.glob(pattern):
@@ -474,6 +473,49 @@ def update_log_total_duration(dataLogFile, total_duration):
                 f.writelines(updated_lines)
     except Exception:
         traceback.print_exc()
+
+
+def read_log_total_time_from_file(log_uuid):
+    """
+    从 .olivadicelog 文件读取累计时长。
+    优先读文件头 log_total_duration 记录的 total_time；
+    若 total_time 为 0（从未成功 off），则 fallback 到首条与末条消息的时间差。
+    返回 float（秒），文件不存在返回 None。
+    """
+    dataPath = OlivaDiceLogger.data.dataPath
+    dataLogPath = OlivaDiceLogger.data.dataLogPath
+    log_dir = dataPath + dataLogPath
+    log_files = glob.glob(f'{log_dir}/log_{log_uuid}_*.olivadicelog')
+    if not log_files:
+        return None
+    try:
+        total_time = 0
+        first_msg_time = None
+        last_msg_time = None
+        with open(log_files[0], 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if record.get('type') == 'log_total_duration':
+                    total_time = record.get('total_time', 0)
+                elif 'time' in record:
+                    if first_msg_time is None:
+                        first_msg_time = record['time']
+                    last_msg_time = record['time']
+        # total_time > 0 说明有成功 off 过，累计值可信
+        if total_time > 0:
+            return total_time
+        # total_time == 0：从未成功 off，用首尾时间差近似
+        if first_msg_time is not None and last_msg_time is not None:
+            return last_msg_time - first_msg_time
+        return 0
+    except Exception:
+        return 0
 
 
 def releaseLogFile(logName, total_duration=0, temp=False):

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -98,10 +98,12 @@ dictStrCustom = {
     'strLoggerStatUserFormat': '[{tUserName}]的数据:\n{tUserStatData}',
     'strLoggerStatUserSeparator': '\n\n',
     # 跨平台续接
-    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code <UUID>',
+    'strLoggerLogId': '当前群号/频道号: {tGroupId}',
+    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号)\n使用 .log id 查看当前群号',
     'strLoggerLogCodeNotFound': '未找到UUID [{tLogUUID}] 对应的日志文件',
+    'strLoggerLogCodeGroupInvalid': '指定的群/频道未找到UUID [{tLogUUID}] 的活跃日志，无法生成续接码',
     'strLoggerLogCodeSuccess': '已为日志 [{tLogName}] 生成续接码\nUUID: {tLogUUID}\n续接码: {tContinueCode}\n一次性，使用后失效\n在目标群使用: .log continue {tLogUUID} {tContinueCode}',
-    'strLoggerLogContinueNoArgs': '请指定UUID和续接码\n格式: .log continue <UUID> <续接码>',
+    'strLoggerLogContinueNoArgs': '请指定UUID和续接码\n格式: .log resume [UUID] [续接码]',
     'strLoggerLogContinueCodeInvalid': '续接码无效或已过期',
     'strLoggerLogContinueNotFound': '未找到UUID对应的日志文件，续接码已作废',
     'strLoggerLogContinueSuccess': '日志续接成功！\n日志 [{tLogName}] (UUID: {tLogUUID})\n当前已记录 {tLogLines} 行，累计时长 {tLogTime}\n已开始记录',
@@ -126,6 +128,7 @@ dictTValue = {
     'tTotalFail': '0',
     'tSuccessRate': '0.00',
     'tContinueCode': 'N/A',
+    'tGroupId': 'N/A',
 }
 
 dictHelpDocTemp = {
@@ -151,10 +154,13 @@ dictHelpDocTemp = {
     开启后日志记录时将使用发送者的角色卡名字
 .log stat (UUID) (all/@用户) 查看日志统计数据
     不带参数查看当前活跃日志中自己的数据
-.log code [UUID] 生成续接码(仅Master)
-    续接码一次性，使用后失效
+.log id 查看当前群号/频道号
+.log code [UUID] (群号) 生成跨平台续接码(仅Master)
+    群号为来源群，不填默认当前群
+    需该群正在记录此UUID，续接码一次性
 .log resume [UUID] [续接码] 跨平台续接日志
-    在任意群使用，使用后该群可续接日志
+    别名: .log continue
+    在任意群使用，无需身份验证
 
 日志的默认名称为 default
 日志上传存在失败可能，届时请联系后台管理索取""",

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -99,7 +99,7 @@ dictStrCustom = {
     'strLoggerStatUserSeparator': '\n\n',
     # 跨平台续接
     'strLoggerLogId': '当前群号/频道号: {tGroupId}',
-    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号)\n使用 .log id 查看当前群号',
+    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号) (平台)\n使用 .log id 查看当前群号',
     'strLoggerLogCodeNotFound': '未找到UUID [{tLogUUID}] 对应的日志文件',
     'strLoggerLogCodeGroupInvalid': '指定的群/频道未找到UUID [{tLogUUID}] 的活跃日志，无法生成续接码',
     'strLoggerLogCodeSuccess': '已为日志 [{tLogName}] 生成续接码\nUUID: {tLogUUID}\n续接码: {tContinueCode}\n一次性，使用后失效\n在目标群使用: .log continue {tLogUUID} {tContinueCode}',
@@ -155,8 +155,9 @@ dictHelpDocTemp = {
 .log stat (UUID) (all/@用户) 查看日志统计数据
     不带参数查看当前活跃日志中自己的数据
 .log id 查看当前群号/频道号
-.log code [UUID] (群号) 生成跨平台续接码(仅Master)
+.log code [UUID] (群号) (平台) 生成跨平台续接码(仅Master)
     群号为来源群，不填默认当前群
+    平台不填默认当前平台，跨平台时需指定
     需该群正在记录此UUID，续接码一次性
 .log resume [UUID] [续接码] 跨平台续接日志
     别名: .log continue

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -14,7 +14,14 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-dictConsoleSwitchTemplate = {'default': {'defaultLogQuote': 0, 'defaultLogUsePcName': 0, 'defaultLogUploadTimeout': 60}}
+dictConsoleSwitchTemplate = {
+    'default': {
+        'defaultLogQuote': 0,
+        'defaultLogUsePcName': 0,
+        'defaultLogUploadTimeout': 60,
+        'defaultLogContinueCodeTTL': 86400,
+    }
+}
 
 dictConfigKeyToConsoleSwitchMapping = {
     'logQuote': 'defaultLogQuote',
@@ -90,6 +97,14 @@ dictStrCustom = {
     'strLoggerStatPcCardSeparator': '\n\n',
     'strLoggerStatUserFormat': '[{tUserName}]的数据:\n{tUserStatData}',
     'strLoggerStatUserSeparator': '\n\n',
+    # 跨平台续接
+    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code <UUID>',
+    'strLoggerLogCodeNotFound': '未找到UUID [{tLogUUID}] 对应的日志文件',
+    'strLoggerLogCodeSuccess': '已为日志 [{tLogName}] 生成续接码\nUUID: {tLogUUID}\n续接码: {tContinueCode}\n一次性，使用后失效\n在目标群使用: .log continue {tLogUUID} {tContinueCode}',
+    'strLoggerLogContinueNoArgs': '请指定UUID和续接码\n格式: .log continue <UUID> <续接码>',
+    'strLoggerLogContinueCodeInvalid': '续接码无效或已过期',
+    'strLoggerLogContinueNotFound': '未找到UUID对应的日志文件，续接码已作废',
+    'strLoggerLogContinueSuccess': '日志续接成功！\n日志 [{tLogName}] (UUID: {tLogUUID})\n当前已记录 {tLogLines} 行，累计时长 {tLogTime}\n已开始记录',
 }
 # flake8: NOQA OFF
 
@@ -110,6 +125,7 @@ dictTValue = {
     'tTotalSuccess': '0',
     'tTotalFail': '0',
     'tSuccessRate': '0.00',
+    'tContinueCode': 'N/A',
 }
 
 dictHelpDocTemp = {
@@ -135,6 +151,10 @@ dictHelpDocTemp = {
     开启后日志记录时将使用发送者的角色卡名字
 .log stat (UUID) (all/@用户) 查看日志统计数据
     不带参数查看当前活跃日志中自己的数据
+.log code [UUID] 生成续接码(仅Master)
+    续接码一次性，使用后失效
+.log resume [UUID] [续接码] 跨平台续接日志
+    在任意群使用，使用后该群可续接日志
 
 日志的默认名称为 default
 日志上传存在失败可能，届时请联系后台管理索取""",

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -1119,6 +1119,54 @@ def unity_reply(plugin_event, Proc):
                                         ensure_ascii=False,
                                     ),
                                 )
+                            if (
+                                plugin_event.platform['platform'] == 'qqGuild'
+                                and plugin_event.indeAPI.hasAPI('create_markdown_message')
+                            ):
+                                extend_data = plugin_event.data.extend
+                                chat_type = (
+                                    'qq_group'
+                                    if extend_data.get('flag_from_qq', False)
+                                    else 'guild_channel'
+                                )
+                                plugin_event.indeAPI.create_markdown_message(
+                                    chat_type=chat_type,
+                                    chat_id=plugin_event.data.group_id,
+                                    markdown={
+                                        'content': (
+                                            '# 日志提取\n'
+                                            '您的日志将在 7 天后过期，请尽快提取。\n'
+                                            '> OlivaDice - 青果核心掷骰机器人'
+                                        )
+                                    },
+                                    keyboard={
+                                        'content': {
+                                            'rows': [
+                                                {
+                                                    'buttons': [
+                                                        {
+                                                            'id': 'extract_log',
+                                                            'render_data': {
+                                                                'label': '点我提取日志',
+                                                                'visited_label': '已提取',
+                                                                'style': 1,
+                                                            },
+                                                            'action': {
+                                                                'type': 0,
+                                                                'permission': {
+                                                                    'type': 2,
+                                                                },
+                                                                'data': str(dictTValue['tLogUrl']),
+                                                                'unsupport_tips': '当前客户端不支持按钮，请复制上方链接提取',
+                                                            },
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    msg_id=extend_data.get('reply_msg_id'),
+                                )
                         except Exception:
                             traceback.print_exc()
                 except Exception:

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -181,8 +181,8 @@ def unity_reply(plugin_event, Proc):
             tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'log')
             tmp_reast_str = skipSpaceStart(tmp_reast_str)
             tmp_reply_str = None
-            # log stop/code 无视锁定状态，直接执行
-            if not isMatchWordStart(tmp_reast_str, ['stop', 'halt', 'code']):
+            # log stop/code/id 无视锁定状态，直接执行
+            if not isMatchWordStart(tmp_reast_str, ['stop', 'halt', 'code', 'id']):
                 log_ending_lock = OlivaDiceCore.userConfig.getUserConfigByKey(
                     userId=tmp_hagID,
                     userType='group',
@@ -2363,6 +2363,14 @@ def unity_reply(plugin_event, Proc):
                             )
                     replyMsg(plugin_event, tmp_reply_str)
                 return
+            elif isMatchWordStart(tmp_reast_str, 'id'):
+                tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'id')
+                dictTValue['tGroupId'] = str(plugin_event.data.group_id)
+                tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                    dictStrCustom['strLoggerLogId'], dictTValue
+                )
+                replyMsg(plugin_event, tmp_reply_str)
+                return
             elif isMatchWordStart(tmp_reast_str, 'code'):
                 tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'code')
                 tmp_reast_str = skipSpaceStart(tmp_reast_str)
@@ -2379,14 +2387,18 @@ def unity_reply(plugin_event, Proc):
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
-                # 参数：UUID（必须）
-                log_uuid = tmp_reast_str.strip()
-                if not log_uuid:
+                # 参数：UUID（36位）+ 群号（可选，默认当前群）
+                tmp_code_input = tmp_reast_str.strip()
+                if len(tmp_code_input) < 36:
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
                         dictStrCustom['strLoggerLogCodeNoUUID'], dictTValue
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
+                log_uuid = tmp_code_input[:36]
+                input_group_id = tmp_code_input[36:].strip()
+                if not input_group_id:
+                    input_group_id = str(plugin_event.data.group_id)
                 # 校验 UUID 对应的日志文件是否存在
                 log_dir = OlivaDiceLogger.data.dataPath + OlivaDiceLogger.data.dataLogPath
                 log_files = glob.glob(f'{log_dir}/log_{log_uuid}_*.olivadicelog')
@@ -2394,6 +2406,37 @@ def unity_reply(plugin_event, Proc):
                     dictTValue['tLogUUID'] = log_uuid
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
                         dictStrCustom['strLoggerLogCodeNotFound'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 校验来源群：该群在当前平台/bot下须持有该 UUID 的活跃日志
+                old_group_hash = OlivaDiceCore.userConfig.getUserHash(
+                    input_group_id, 'group', plugin_event.platform['platform']
+                )
+                old_log_enable = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId=old_group_hash,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logEnable',
+                    botHash=plugin_event.bot_info.hash,
+                )
+                old_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId=old_group_hash,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameDict',
+                    botHash=plugin_event.bot_info.hash,
+                )
+                old_has_uuid = False
+                if old_log_enable and old_name_dict:
+                    for tmp_v in old_name_dict.values():
+                        if tmp_v == log_uuid:
+                            old_has_uuid = True
+                            break
+                if not old_has_uuid:
+                    dictTValue['tLogUUID'] = log_uuid
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogCodeGroupInvalid'], dictTValue
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
@@ -2417,6 +2460,8 @@ def unity_reply(plugin_event, Proc):
                 OlivaDiceLogger.data.dictContinueCode[log_uuid] = {
                     'code': continue_code,
                     'time': time.time(),
+                    'old_group_hash': old_group_hash,
+                    'old_bot_hash': plugin_event.bot_info.hash,
                 }
                 # 提取日志名用于回复
                 log_filename = os.path.basename(log_files[0])
@@ -2442,21 +2487,14 @@ def unity_reply(plugin_event, Proc):
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
-                # 尝试按空格分割
-                tmp_parts = tmp_args.split(None, 1)
-                if len(tmp_parts) == 2:
-                    log_uuid = tmp_parts[0].strip()
-                    input_code = tmp_parts[1].strip()
-                elif len(tmp_parts) == 1 and len(tmp_parts[0]) > 36:
-                    # 无空格情况：UUID 固定 36 字符（8-4-4-4-12 格式）
-                    log_uuid = tmp_parts[0][:36]
-                    input_code = tmp_parts[0][36:].strip()
-                else:
+                if len(tmp_args) <= 6:
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
                         dictStrCustom['strLoggerLogContinueNoArgs'], dictTValue
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
+                input_code = tmp_args[-6:]
+                log_uuid = tmp_args[:-6].strip()
                 if not log_uuid or not input_code:
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
                         dictStrCustom['strLoggerLogContinueNoArgs'], dictTValue
@@ -2503,6 +2541,76 @@ def unity_reply(plugin_event, Proc):
                     return
                 # 续接码验证通过，立即销毁（一次性）
                 del OlivaDiceLogger.data.dictContinueCode[log_uuid]
+                # 关闭旧群日志（跨群/跨 bot 时）
+                old_group_hash = code_entry.get('old_group_hash')
+                old_bot_hash = code_entry.get('old_bot_hash')
+                if old_group_hash and (
+                    old_group_hash != tmp_hagID
+                    or old_bot_hash != plugin_event.bot_info.hash
+                ):
+                    # 旧群 logEnable → False
+                    OlivaDiceCore.userConfig.setUserConfigByKey(
+                        userId=old_group_hash,
+                        userType='group',
+                        platform='',
+                        userConfigKey='logEnable',
+                        userConfigValue=False,
+                        botHash=old_bot_hash,
+                    )
+                    # 旧群 timeDict：补 end_time
+                    old_time_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                        userId=old_group_hash,
+                        userType='group',
+                        platform='',
+                        userConfigKey='logNameTimeDict',
+                        botHash=old_bot_hash,
+                    )
+                    old_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                        userId=old_group_hash,
+                        userType='group',
+                        platform='',
+                        userConfigKey='logNameDict',
+                        botHash=old_bot_hash,
+                    )
+                    if old_time_dict and old_name_dict:
+                        old_matched_name = None
+                        for tmp_n, tmp_u in old_name_dict.items():
+                            if tmp_u == log_uuid and tmp_n in old_time_dict:
+                                if old_time_dict[tmp_n].get('end_time', 0) == 0:
+                                    tmp_now_time = time.time()
+                                    tmp_start = old_time_dict[tmp_n].get('start_time', 0)
+                                    if tmp_start > 0:
+                                        old_time_dict[tmp_n]['total_time'] = (
+                                            old_time_dict[tmp_n].get('total_time', 0)
+                                            + (tmp_now_time - tmp_start)
+                                        )
+                                    old_time_dict[tmp_n]['end_time'] = tmp_now_time
+                                old_matched_name = tmp_n
+                                break
+                        OlivaDiceCore.userConfig.setUserConfigByKey(
+                            userId=old_group_hash,
+                            userType='group',
+                            platform='',
+                            userConfigKey='logNameTimeDict',
+                            userConfigValue=old_time_dict,
+                            botHash=old_bot_hash,
+                        )
+                        # 同步写文件头 total_duration
+                        if old_matched_name:
+                            tmp_old_logName = f'log_{log_uuid}_{old_matched_name}'
+                            tmp_old_file = (
+                                OlivaDiceLogger.data.dataPath
+                                + OlivaDiceLogger.data.dataLogPath
+                                + f'/{tmp_old_logName}.olivadicelog'
+                            )
+                            OlivaDiceLogger.logger.update_log_total_duration(
+                                tmp_old_file,
+                                old_time_dict[old_matched_name].get('total_time', 0),
+                            )
+                    # 持久化旧群 config
+                    OlivaDiceCore.userConfig.writeUserConfigByUserHash(
+                        userHash=old_group_hash
+                    )
                 # 提取日志名
                 log_filename = os.path.basename(log_files[0])
                 log_name = log_filename.replace(
@@ -2536,25 +2644,34 @@ def unity_reply(plugin_event, Proc):
                 )
                 if log_name_time_dict is None:
                     log_name_time_dict = {}
-                # 如果本群已有同名日志，追加序号避免冲突
-                tmp_log_name = log_name
-                name_counter = 1
-                while tmp_log_name in log_name_list:
-                    tmp_log_name = f'{log_name}_{name_counter}'
-                    name_counter += 1
-                log_name = tmp_log_name
                 # 从文件读取累计时长（含 fallback），start_time 设为当前
                 file_total_time = OlivaDiceLogger.logger.read_log_total_time_from_file(log_uuid)
                 if file_total_time is None:
                     file_total_time = 0
+                # 检查本群是否已注册该 UUID
+                existing_name = None
+                for tmp_name, tmp_uid in log_name_dict.items():
+                    if tmp_uid == log_uuid:
+                        existing_name = tmp_name
+                        break
+                if existing_name is not None:
+                    # 已存在：复用原条目，重新激活
+                    log_name = existing_name
+                else:
+                    # 新条目：避免同名冲突
+                    tmp_log_name = log_name
+                    name_counter = 1
+                    while tmp_log_name in log_name_list:
+                        tmp_log_name = f'{log_name}_{name_counter}'
+                        name_counter += 1
+                    log_name = tmp_log_name
+                    log_name_list.append(log_name)
+                    log_name_dict[log_name] = log_uuid
                 log_name_time_dict[log_name] = {
                     'start_time': time.time(),
                     'end_time': 0,
                     'total_time': file_total_time,
                 }
-                # 注册到当前群 config
-                log_name_list.append(log_name)
-                log_name_dict[log_name] = log_uuid
                 OlivaDiceCore.userConfig.setUserConfigByKey(
                     userId=tmp_hagID,
                     userType='group',

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -2435,7 +2435,7 @@ def unity_reply(plugin_event, Proc):
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
-                # 参数：UUID（36位）+ 群号（可选，默认当前群）
+                # 参数：UUID（36位）+ 群号（可选）+ 平台（可选）
                 tmp_code_input = tmp_reast_str.strip()
                 if len(tmp_code_input) < 36:
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
@@ -2444,9 +2444,16 @@ def unity_reply(plugin_event, Proc):
                     replyMsg(plugin_event, tmp_reply_str)
                     return
                 log_uuid = tmp_code_input[:36]
-                input_group_id = tmp_code_input[36:].strip()
-                if not input_group_id:
+                tmp_code_rest = tmp_code_input[36:].strip()
+                tmp_code_parts = tmp_code_rest.split() if tmp_code_rest else []
+                if len(tmp_code_parts) >= 1:
+                    input_group_id = tmp_code_parts[0]
+                else:
                     input_group_id = str(plugin_event.data.group_id)
+                if len(tmp_code_parts) >= 2:
+                    input_platform = tmp_code_parts[1]
+                else:
+                    input_platform = plugin_event.platform['platform']
                 # 校验 UUID 对应的日志文件是否存在
                 log_dir = OlivaDiceLogger.data.dataPath + OlivaDiceLogger.data.dataLogPath
                 log_files = glob.glob(f'{log_dir}/log_{log_uuid}_*.olivadicelog')
@@ -2457,28 +2464,20 @@ def unity_reply(plugin_event, Proc):
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
-                # 校验来源群：该群在当前平台/bot下须持有该 UUID 的活跃日志
+                # 校验来源群：遍历该群所有 botHash 条目，须持有该 UUID 的活跃日志
                 old_group_hash = OlivaDiceCore.userConfig.getUserHash(
-                    input_group_id, 'group', plugin_event.platform['platform']
-                )
-                old_log_enable = OlivaDiceCore.userConfig.getUserConfigByKey(
-                    userId=old_group_hash,
-                    userType='group',
-                    platform=plugin_event.platform['platform'],
-                    userConfigKey='logEnable',
-                    botHash=plugin_event.bot_info.hash,
-                )
-                old_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
-                    userId=old_group_hash,
-                    userType='group',
-                    platform=plugin_event.platform['platform'],
-                    userConfigKey='logNameDict',
-                    botHash=plugin_event.bot_info.hash,
+                    input_group_id, 'group', input_platform
                 )
                 old_has_uuid = False
-                if old_log_enable and old_name_dict:
-                    for tmp_v in old_name_dict.values():
-                        if tmp_v == log_uuid:
+                tmp_user_config_data = OlivaDiceCore.userConfig.dictUserConfigData
+                if old_group_hash in tmp_user_config_data:
+                    for tmp_bot_key in tmp_user_config_data[old_group_hash]:
+                        tmp_entry = tmp_user_config_data[old_group_hash][tmp_bot_key]
+                        tmp_config_note = tmp_entry.get('configNote', {})
+                        if not tmp_config_note.get('logEnable', False):
+                            continue
+                        tmp_name_dict = tmp_config_note.get('logNameDict', {})
+                        if log_uuid in tmp_name_dict.values():
                             old_has_uuid = True
                             break
                 if not old_has_uuid:
@@ -2509,7 +2508,6 @@ def unity_reply(plugin_event, Proc):
                     'code': continue_code,
                     'time': time.time(),
                     'old_group_hash': old_group_hash,
-                    'old_bot_hash': plugin_event.bot_info.hash,
                 }
                 # 提取日志名用于回复
                 log_filename = os.path.basename(log_files[0])
@@ -2589,76 +2587,56 @@ def unity_reply(plugin_event, Proc):
                     return
                 # 续接码验证通过，立即销毁（一次性）
                 del OlivaDiceLogger.data.dictContinueCode[log_uuid]
-                # 关闭旧群日志（跨群/跨 bot 时）
+                # 关闭旧群日志（跨群/跨平台时）
                 old_group_hash = code_entry.get('old_group_hash')
-                old_bot_hash = code_entry.get('old_bot_hash')
-                if old_group_hash and (
-                    old_group_hash != tmp_hagID
-                    or old_bot_hash != plugin_event.bot_info.hash
-                ):
-                    # 旧群 logEnable → False
-                    OlivaDiceCore.userConfig.setUserConfigByKey(
-                        userId=old_group_hash,
-                        userType='group',
-                        platform='',
-                        userConfigKey='logEnable',
-                        userConfigValue=False,
-                        botHash=old_bot_hash,
-                    )
-                    # 旧群 timeDict：补 end_time
-                    old_time_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
-                        userId=old_group_hash,
-                        userType='group',
-                        platform='',
-                        userConfigKey='logNameTimeDict',
-                        botHash=old_bot_hash,
-                    )
-                    old_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
-                        userId=old_group_hash,
-                        userType='group',
-                        platform='',
-                        userConfigKey='logNameDict',
-                        botHash=old_bot_hash,
-                    )
-                    if old_time_dict and old_name_dict:
-                        old_matched_name = None
-                        for tmp_n, tmp_u in old_name_dict.items():
-                            if tmp_u == log_uuid and tmp_n in old_time_dict:
-                                if old_time_dict[tmp_n].get('end_time', 0) == 0:
-                                    tmp_now_time = time.time()
-                                    tmp_start = old_time_dict[tmp_n].get('start_time', 0)
-                                    if tmp_start > 0:
-                                        old_time_dict[tmp_n]['total_time'] = (
-                                            old_time_dict[tmp_n].get('total_time', 0)
-                                            + (tmp_now_time - tmp_start)
-                                        )
-                                    old_time_dict[tmp_n]['end_time'] = tmp_now_time
-                                old_matched_name = tmp_n
-                                break
-                        OlivaDiceCore.userConfig.setUserConfigByKey(
-                            userId=old_group_hash,
-                            userType='group',
-                            platform='',
-                            userConfigKey='logNameTimeDict',
-                            userConfigValue=old_time_dict,
-                            botHash=old_bot_hash,
+                tmp_current_group_hash = OlivaDiceCore.userConfig.getUserHash(
+                    tmp_hagID, 'group', plugin_event.platform['platform']
+                )
+                if old_group_hash and old_group_hash != tmp_current_group_hash:
+                    tmp_user_config_data = OlivaDiceCore.userConfig.dictUserConfigData
+                    if old_group_hash in tmp_user_config_data:
+                        for tmp_bot_key in tmp_user_config_data[old_group_hash]:
+                            tmp_entry = tmp_user_config_data[old_group_hash][tmp_bot_key]
+                            tmp_config_note = tmp_entry.get('configNote', {})
+                            if not tmp_config_note.get('logEnable', False):
+                                continue
+                            tmp_name_dict = tmp_config_note.get('logNameDict', {})
+                            if log_uuid not in tmp_name_dict.values():
+                                continue
+                            # 关闭该 botHash 下的日志
+                            tmp_config_note['logEnable'] = False
+                            # 补时间
+                            tmp_time_dict = tmp_config_note.get('logNameTimeDict', {})
+                            if tmp_time_dict and tmp_name_dict:
+                                for tmp_n, tmp_u in tmp_name_dict.items():
+                                    if tmp_u != log_uuid or tmp_n not in tmp_time_dict:
+                                        continue
+                                    if tmp_time_dict[tmp_n].get('end_time', 0) == 0:
+                                        tmp_now_time = time.time()
+                                        tmp_start = tmp_time_dict[tmp_n].get('start_time', 0)
+                                        if tmp_start > 0:
+                                            tmp_time_dict[tmp_n]['total_time'] = (
+                                                tmp_time_dict[tmp_n].get('total_time', 0)
+                                                + (tmp_now_time - tmp_start)
+                                            )
+                                        tmp_time_dict[tmp_n]['end_time'] = tmp_now_time
+                                    # 同步写文件头 total_duration
+                                    tmp_old_logName = f'log_{log_uuid}_{tmp_n}'
+                                    tmp_old_file = (
+                                        OlivaDiceLogger.data.dataPath
+                                        + OlivaDiceLogger.data.dataLogPath
+                                        + f'/{tmp_old_logName}.olivadicelog'
+                                    )
+                                    OlivaDiceLogger.logger.update_log_total_duration(
+                                        tmp_old_file,
+                                        tmp_time_dict[tmp_n].get('total_time', 0),
+                                    )
+                                    break
+                                tmp_config_note['logNameTimeDict'] = tmp_time_dict
+                        # 持久化旧群 config
+                        OlivaDiceCore.userConfig.writeUserConfigByUserHash(
+                            userHash=old_group_hash
                         )
-                        # 同步写文件头 total_duration
-                        if old_matched_name:
-                            tmp_old_logName = f'log_{log_uuid}_{old_matched_name}'
-                            tmp_old_file = (
-                                OlivaDiceLogger.data.dataPath
-                                + OlivaDiceLogger.data.dataLogPath
-                                + f'/{tmp_old_logName}.olivadicelog'
-                            )
-                            OlivaDiceLogger.logger.update_log_total_duration(
-                                tmp_old_file,
-                                old_time_dict[old_matched_name].get('total_time', 0),
-                            )
-                    # 持久化旧群 config
-                    OlivaDiceCore.userConfig.writeUserConfigByUserHash(
-                        userHash=old_group_hash
-                    )
                 # 提取日志名
                 log_filename = os.path.basename(log_files[0])
                 log_name = log_filename.replace(

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -181,8 +181,8 @@ def unity_reply(plugin_event, Proc):
             tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'log')
             tmp_reast_str = skipSpaceStart(tmp_reast_str)
             tmp_reply_str = None
-            # log stop 无视锁定状态，直接执行
-            if not isMatchWordStart(tmp_reast_str, ['stop', 'halt']):
+            # log stop/code 无视锁定状态，直接执行
+            if not isMatchWordStart(tmp_reast_str, ['stop', 'halt', 'code']):
                 log_ending_lock = OlivaDiceCore.userConfig.getUserConfigByKey(
                     userId=tmp_hagID,
                     userType='group',
@@ -2362,6 +2362,261 @@ def unity_reply(plugin_event, Proc):
                                 dictStrCustom['strLoggerLogStatSelf'], dictTValue
                             )
                     replyMsg(plugin_event, tmp_reply_str)
+                return
+            elif isMatchWordStart(tmp_reast_str, 'code'):
+                tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'code')
+                tmp_reast_str = skipSpaceStart(tmp_reast_str)
+                # 权限：仅骰主
+                flag_is_from_master = OlivaDiceCore.ordinaryInviteManager.isInMasterList(
+                    plugin_event.bot_info.hash,
+                    OlivaDiceCore.userConfig.getUserHash(
+                        plugin_event.data.user_id, 'user', plugin_event.platform['platform']
+                    ),
+                )
+                if not flag_is_from_master:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strNeedMaster'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 参数：UUID（必须）
+                log_uuid = tmp_reast_str.strip()
+                if not log_uuid:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogCodeNoUUID'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 校验 UUID 对应的日志文件是否存在
+                log_dir = OlivaDiceLogger.data.dataPath + OlivaDiceLogger.data.dataLogPath
+                log_files = glob.glob(f'{log_dir}/log_{log_uuid}_*.olivadicelog')
+                if not log_files:
+                    dictTValue['tLogUUID'] = log_uuid
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogCodeNotFound'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 懒加载：清理过期码
+                tmp_ttl = OlivaDiceCore.console.getConsoleSwitchByHash(
+                    'defaultLogContinueCodeTTL', plugin_event.bot_info.hash
+                )
+                if tmp_ttl is None:
+                    tmp_ttl = 86400
+                if tmp_ttl > 0:
+                    tmp_now = time.time()
+                    tmp_expired_keys = [
+                        k for k, v in OlivaDiceLogger.data.dictContinueCode.items()
+                        if tmp_now - v['time'] > tmp_ttl
+                    ]
+                    for k in tmp_expired_keys:
+                        del OlivaDiceLogger.data.dictContinueCode[k]
+                # 生成 6 位续接码（uuid4 hex 取前 6 位，大写）
+                continue_code = uuid.uuid4().hex[:6].upper()
+                # 存入内存（覆盖旧码，同一 UUID 同时只保留一个有效码）
+                OlivaDiceLogger.data.dictContinueCode[log_uuid] = {
+                    'code': continue_code,
+                    'time': time.time(),
+                }
+                # 提取日志名用于回复
+                log_filename = os.path.basename(log_files[0])
+                log_name_display = log_filename.replace(
+                    f'log_{log_uuid}_', ''
+                ).replace('.olivadicelog', '')
+                dictTValue['tLogUUID'] = log_uuid
+                dictTValue['tLogName'] = log_name_display
+                dictTValue['tContinueCode'] = continue_code
+                tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                    dictStrCustom['strLoggerLogCodeSuccess'], dictTValue
+                )
+                replyMsg(plugin_event, tmp_reply_str)
+                return
+            elif isMatchWordStart(tmp_reast_str, ['continue', 'resume']):
+                tmp_reast_str = getMatchWordStartRight(tmp_reast_str, ['continue', 'resume'])
+                tmp_reast_str = skipSpaceStart(tmp_reast_str)
+                # 解析参数：UUID + 续接码
+                tmp_args = tmp_reast_str.strip()
+                if not tmp_args:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogContinueNoArgs'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 尝试按空格分割
+                tmp_parts = tmp_args.split(None, 1)
+                if len(tmp_parts) == 2:
+                    log_uuid = tmp_parts[0].strip()
+                    input_code = tmp_parts[1].strip()
+                elif len(tmp_parts) == 1 and len(tmp_parts[0]) > 36:
+                    # 无空格情况：UUID 固定 36 字符（8-4-4-4-12 格式）
+                    log_uuid = tmp_parts[0][:36]
+                    input_code = tmp_parts[0][36:].strip()
+                else:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogContinueNoArgs'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                if not log_uuid or not input_code:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogContinueNoArgs'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 懒加载：遍历全量清理所有过期码
+                tmp_ttl = OlivaDiceCore.console.getConsoleSwitchByHash(
+                    'defaultLogContinueCodeTTL', plugin_event.bot_info.hash
+                )
+                if tmp_ttl is None:
+                    tmp_ttl = 86400
+                if tmp_ttl > 0:
+                    tmp_now = time.time()
+                    tmp_expired_keys = [
+                        k for k, v in OlivaDiceLogger.data.dictContinueCode.items()
+                        if tmp_now - v['time'] > tmp_ttl
+                    ]
+                    for k in tmp_expired_keys:
+                        del OlivaDiceLogger.data.dictContinueCode[k]
+                # 校验续接码（不存在/过期/重载丢失/码不匹配 → 统一回复）
+                if log_uuid not in OlivaDiceLogger.data.dictContinueCode:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogContinueCodeInvalid'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                code_entry = OlivaDiceLogger.data.dictContinueCode[log_uuid]
+                if input_code.upper() != code_entry['code']:
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogContinueCodeInvalid'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 校验 UUID 对应的日志文件是否存在
+                log_dir = OlivaDiceLogger.data.dataPath + OlivaDiceLogger.data.dataLogPath
+                log_files = glob.glob(f'{log_dir}/log_{log_uuid}_*.olivadicelog')
+                if not log_files:
+                    del OlivaDiceLogger.data.dictContinueCode[log_uuid]
+                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogContinueNotFound'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str)
+                    return
+                # 续接码验证通过，立即销毁（一次性）
+                del OlivaDiceLogger.data.dictContinueCode[log_uuid]
+                # 提取日志名
+                log_filename = os.path.basename(log_files[0])
+                log_name = log_filename.replace(
+                    f'log_{log_uuid}_', ''
+                ).replace('.olivadicelog', '')
+                # 读取当前群 config
+                log_name_list = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameList',
+                    botHash=plugin_event.bot_info.hash,
+                )
+                if log_name_list is None:
+                    log_name_list = []
+                log_name_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameDict',
+                    botHash=plugin_event.bot_info.hash,
+                )
+                if log_name_dict is None:
+                    log_name_dict = {}
+                log_name_time_dict = OlivaDiceCore.userConfig.getUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameTimeDict',
+                    botHash=plugin_event.bot_info.hash,
+                )
+                if log_name_time_dict is None:
+                    log_name_time_dict = {}
+                # 如果本群已有同名日志，追加序号避免冲突
+                tmp_log_name = log_name
+                name_counter = 1
+                while tmp_log_name in log_name_list:
+                    tmp_log_name = f'{log_name}_{name_counter}'
+                    name_counter += 1
+                log_name = tmp_log_name
+                # 从文件读取累计时长（含 fallback），start_time 设为当前
+                file_total_time = OlivaDiceLogger.logger.read_log_total_time_from_file(log_uuid)
+                if file_total_time is None:
+                    file_total_time = 0
+                log_name_time_dict[log_name] = {
+                    'start_time': time.time(),
+                    'end_time': 0,
+                    'total_time': file_total_time,
+                }
+                # 注册到当前群 config
+                log_name_list.append(log_name)
+                log_name_dict[log_name] = log_uuid
+                OlivaDiceCore.userConfig.setUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameList',
+                    userConfigValue=log_name_list,
+                    botHash=plugin_event.bot_info.hash,
+                )
+                OlivaDiceCore.userConfig.setUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameDict',
+                    userConfigValue=log_name_dict,
+                    botHash=plugin_event.bot_info.hash,
+                )
+                OlivaDiceCore.userConfig.setUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logNameTimeDict',
+                    userConfigValue=log_name_time_dict,
+                    botHash=plugin_event.bot_info.hash,
+                )
+                # 设为活跃日志并开始记录（不触发 logQuote）
+                OlivaDiceCore.userConfig.setUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logActiveName',
+                    userConfigValue=log_name,
+                    botHash=plugin_event.bot_info.hash,
+                )
+                OlivaDiceCore.userConfig.setUserConfigByKey(
+                    userId=tmp_hagID,
+                    userType='group',
+                    platform=plugin_event.platform['platform'],
+                    userConfigKey='logEnable',
+                    userConfigValue=True,
+                    botHash=plugin_event.bot_info.hash,
+                )
+                # 持久化
+                OlivaDiceCore.userConfig.writeUserConfigByUserHash(
+                    userHash=OlivaDiceCore.userConfig.getUserHash(
+                        tmp_hagID, 'group', plugin_event.platform['platform']
+                    )
+                )
+                # 确保日志文件有 duration 头（兼容老文件）
+                tmp_logName = f'log_{log_uuid}_{log_name}'
+                OlivaDiceLogger.logger.init_log_file(tmp_logName)
+                # 回复（不做 logQuote，跨平台 message_id 无意义）
+                dictTValue['tLogUUID'] = log_uuid
+                dictTValue['tLogName'] = log_name
+                dictTValue['tLogLines'] = str(OlivaDiceLogger.logger.get_log_lines(tmp_logName))
+                total_time = OlivaDiceLogger.logger.read_log_total_time_from_file(log_uuid)
+                dictTValue['tLogTime'] = OlivaDiceLogger.logger.format_duration(
+                    int(total_time) if total_time else 0
+                )
+                tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                    dictStrCustom['strLoggerLogContinueSuccess'], dictTValue
+                )
+                replyMsg(plugin_event, tmp_reply_str)
                 return
             elif isMatchWordStart(tmp_reast_str, ['quote', 'reply']):
                 tmp_reast_str = getMatchWordStartRight(tmp_reast_str, ['quote', 'reply'])


### PR DESCRIPTION
## Summary by Sourcery

Add cross-platform log continuation via UUID-based one-time codes and update logger metadata versioning.

New Features:
- Introduce .log code command for masters to generate one-time continuation codes bound to existing log UUIDs for cross-group/platform use.
- Add .log continue/.log resume commands to attach a group to an existing log by UUID and validated continuation code, restoring duration and activating logging.

Enhancements:
- Provide helper to read cumulative log duration from log files with fallback to first/last message timestamps for legacy logs.
- Expose configurable TTL for continuation codes via console switch with default expiry of 24 hours.
- Extend logger help text and user-facing messages to document log continuation workflow and error cases.
- Refactor glob import usage in logger initialization to module scope and track continuation codes in memory only.