### PR TITLE
feat: 3.0.40 跨平台续接码：双向贪婪匹配平台名、end后缀跳过校验、删除log id指令

### DIFF
--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.39",
-    "svn" : 47,
+    "version" : "3.0.40",
+    "svn" : 48,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.38",
-    "svn" : 46,
+    "version" : "3.0.39",
+    "svn" : 47,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.36",
-    "svn" : 44,
+    "version" : "3.0.37",
+    "svn" : 45,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.37",
-    "svn" : 45,
+    "version" : "3.0.38",
+    "svn" : 46,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.39'
-OlivaDiceLogger_svn = 47
+OlivaDiceLogger_ver = '3.0.40'
+OlivaDiceLogger_svn = 48
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.36'
-OlivaDiceLogger_svn = 44
+OlivaDiceLogger_ver = '3.0.37'
+OlivaDiceLogger_svn = 45
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.37'
-OlivaDiceLogger_svn = 45
+OlivaDiceLogger_ver = '3.0.38'
+OlivaDiceLogger_svn = 46
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.38'
-OlivaDiceLogger_svn = 46
+OlivaDiceLogger_ver = '3.0.39'
+OlivaDiceLogger_svn = 47
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -99,10 +99,10 @@ dictStrCustom = {
     'strLoggerStatUserSeparator': '\n\n',
     # 跨平台续接
     'strLoggerLogId': '当前群号/频道号: {tGroupId}',
-    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号) (平台)\n使用 .log id 查看当前群号',
+    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号[平台])\n群号后可接平台名如 1016912041qq\n使用 .log id 查看当前群号',
     'strLoggerLogCodeNotFound': '未找到UUID [{tLogUUID}] 对应的日志文件',
-    'strLoggerLogCodeGroupInvalid': '指定的群/频道未找到UUID [{tLogUUID}] 的活跃日志，无法生成续接码',
-    'strLoggerLogCodeSuccess': '已为日志 [{tLogName}] 生成续接码\nUUID: {tLogUUID}\n续接码: {tContinueCode}\n一次性，使用后失效\n在目标群使用: .log continue {tLogUUID} {tContinueCode}',
+    'strLoggerLogCodeGroupInvalid': '指定的群/频道未找到UUID [{tLogUUID}] 的日志记录，无法生成续接码',
+    'strLoggerLogCodeSuccess': '已为日志 [{tLogName}] 生成续接码\nUUID: {tLogUUID}\n续接码: {tContinueCode}\n一次性，使用后失效\n在目标群使用: .log resume {tLogUUID} {tContinueCode}',
     'strLoggerLogContinueNoArgs': '请指定UUID和续接码\n格式: .log resume [UUID] [续接码]',
     'strLoggerLogContinueCodeInvalid': '续接码无效或已过期',
     'strLoggerLogContinueNotFound': '未找到UUID对应的日志文件，续接码已作废',
@@ -155,10 +155,12 @@ dictHelpDocTemp = {
 .log stat (UUID) (all/@用户) 查看日志统计数据
     不带参数查看当前活跃日志中自己的数据
 .log id 查看当前群号/频道号
-.log code [UUID] (群号) (平台) 生成跨平台续接码(仅Master)
+.log code [UUID] (群号[平台]) 生成跨平台续接码(仅Master)
     群号为来源群，不填默认当前群
-    平台不填默认当前平台，跨平台时需指定
-    需该群正在记录此UUID，续接码一次性
+    群号后可接平台名(如 1016912041qq)，无需空格分隔，从右往左贪婪匹配
+    省略平台则默认当前平台，跨平台时需指定
+    需该群有该UUID的日志记录即可，日志可已结束
+    UUID后直接加 end 可跳过群校验(用于已 end 的日志)
 .log resume [UUID] [续接码] 跨平台续接日志
     别名: .log continue
     在任意群使用，无需身份验证

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -98,8 +98,7 @@ dictStrCustom = {
     'strLoggerStatUserFormat': '[{tUserName}]的数据:\n{tUserStatData}',
     'strLoggerStatUserSeparator': '\n\n',
     # 跨平台续接
-    'strLoggerLogId': '当前群号/频道号: {tGroupId}\n当前Bot平台: {tPlatform}',
-    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号[平台])\n群号后可接平台名如 1016912041qq\n使用 .log id 查看当前群号',
+    'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号[平台])\n使用 .uinfo group 查看当前群号/频道号(hag_id)和平台',
     'strLoggerLogCodeNotFound': '未找到UUID [{tLogUUID}] 对应的日志文件',
     'strLoggerLogCodeGroupInvalid': '指定的群/频道未找到UUID [{tLogUUID}] 的日志记录，无法生成续接码',
     'strLoggerLogCodeSuccess': '已为日志 [{tLogName}] 生成续接码\nUUID: {tLogUUID}\n续接码: {tContinueCode}\n一次性，使用后失效\n在目标群使用: .log resume {tLogUUID} {tContinueCode}',
@@ -154,13 +153,11 @@ dictHelpDocTemp = {
     开启后日志记录时将使用发送者的角色卡名字
 .log stat (UUID) (all/@用户) 查看日志统计数据
     不带参数查看当前活跃日志中自己的数据
-.log id 查看当前群号/频道号和当前Bot平台
-.log code [UUID] (群号[平台]) 生成跨平台续接码(仅Master)
+.log code [UUID] (群号) (平台) (end) 生成跨平台续接码(仅Master)
     群号为来源群，不填默认当前群
-    群号后可接平台名(如 1016912041qq)，无需空格分隔，从右往左贪婪匹配
-    省略平台则默认当前平台，跨平台时需指定
     需该群有该UUID的日志记录即可，日志可已结束
     UUID后直接加 end 可跳过群校验(用于已 end 的日志)
+    可用 .uinfo group 查看群号/频道号(hag_id)和平台
 .log resume [UUID] [续接码] 跨平台续接日志
     别名: .log continue
     在任意群使用，无需身份验证

--- a/OlivaDiceLogger/msgCustom.py
+++ b/OlivaDiceLogger/msgCustom.py
@@ -98,7 +98,7 @@ dictStrCustom = {
     'strLoggerStatUserFormat': '[{tUserName}]的数据:\n{tUserStatData}',
     'strLoggerStatUserSeparator': '\n\n',
     # 跨平台续接
-    'strLoggerLogId': '当前群号/频道号: {tGroupId}',
+    'strLoggerLogId': '当前群号/频道号: {tGroupId}\n当前Bot平台: {tPlatform}',
     'strLoggerLogCodeNoUUID': '请指定日志UUID\n格式: .log code [UUID] (群号[平台])\n群号后可接平台名如 1016912041qq\n使用 .log id 查看当前群号',
     'strLoggerLogCodeNotFound': '未找到UUID [{tLogUUID}] 对应的日志文件',
     'strLoggerLogCodeGroupInvalid': '指定的群/频道未找到UUID [{tLogUUID}] 的日志记录，无法生成续接码',
@@ -154,7 +154,7 @@ dictHelpDocTemp = {
     开启后日志记录时将使用发送者的角色卡名字
 .log stat (UUID) (all/@用户) 查看日志统计数据
     不带参数查看当前活跃日志中自己的数据
-.log id 查看当前群号/频道号
+.log id 查看当前群号/频道号和当前Bot平台
 .log code [UUID] (群号[平台]) 生成跨平台续接码(仅Master)
     群号为来源群，不填默认当前群
     群号后可接平台名(如 1016912041qq)，无需空格分隔，从右往左贪婪匹配

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -2411,15 +2411,6 @@ def unity_reply(plugin_event, Proc):
                             )
                     replyMsg(plugin_event, tmp_reply_str)
                 return
-            elif isMatchWordStart(tmp_reast_str, 'id'):
-                tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'id')
-                dictTValue['tGroupId'] = tmp_hagID
-                dictTValue['tPlatform'] = plugin_event.platform['platform']
-                tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
-                    dictStrCustom['strLoggerLogId'], dictTValue
-                )
-                replyMsg(plugin_event, tmp_reply_str)
-                return
             elif isMatchWordStart(tmp_reast_str, 'code'):
                 tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'code')
                 tmp_reast_str = skipSpaceStart(tmp_reast_str)

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -2414,6 +2414,7 @@ def unity_reply(plugin_event, Proc):
             elif isMatchWordStart(tmp_reast_str, 'id'):
                 tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'id')
                 dictTValue['tGroupId'] = tmp_hagID
+                dictTValue['tPlatform'] = plugin_event.platform['platform']
                 tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
                     dictStrCustom['strLoggerLogId'], dictTValue
                 )

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -2413,7 +2413,7 @@ def unity_reply(plugin_event, Proc):
                 return
             elif isMatchWordStart(tmp_reast_str, 'id'):
                 tmp_reast_str = getMatchWordStartRight(tmp_reast_str, 'id')
-                dictTValue['tGroupId'] = str(plugin_event.data.group_id)
+                dictTValue['tGroupId'] = tmp_hagID
                 tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
                     dictStrCustom['strLoggerLogId'], dictTValue
                 )
@@ -2435,7 +2435,8 @@ def unity_reply(plugin_event, Proc):
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
-                # 参数：UUID（36位）+ 群号（可选）+ 平台（可选）
+                # 参数：UUID（36位）+ 群号（可选，支持右端接平台名）
+                # 从右往左贪婪匹配：群号后可直接接平台名，无需空格分隔
                 tmp_code_input = tmp_reast_str.strip()
                 if len(tmp_code_input) < 36:
                     tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
@@ -2445,14 +2446,41 @@ def unity_reply(plugin_event, Proc):
                     return
                 log_uuid = tmp_code_input[:36]
                 tmp_code_rest = tmp_code_input[36:].strip()
-                tmp_code_parts = tmp_code_rest.split() if tmp_code_rest else []
-                if len(tmp_code_parts) >= 1:
-                    input_group_id = tmp_code_parts[0]
+                # end 后缀：日志已 end，跳过群校验直接基于文件生成续接码
+                flag_log_ended = (tmp_code_rest == 'end')
+                if flag_log_ended:
+                    old_group_hash = None
+                    input_group_id = str(plugin_event.data.group_id)
+                    input_platform = plugin_event.platform['platform']
+                elif tmp_code_rest:
+                    # 双向贪婪匹配平台名：先右再左
+                    # 平台名列表按长度降序，长名优先匹配（如 qqGuild 优先于 qq）
+                    platform_list_sorted = sorted(
+                        OlivOS.accountMetadataAPI.accountTypeDataList_platform,
+                        key=len, reverse=True
+                    )
+                    matched_platform = None
+                    # 从右往左
+                    for p in platform_list_sorted:
+                        if tmp_code_rest.endswith(p):
+                            matched_platform = p
+                            matched_group_id = tmp_code_rest[:-len(p)]
+                            break
+                    # 从右未命中则从左往右
+                    if matched_platform is None:
+                        for p in platform_list_sorted:
+                            if tmp_code_rest.startswith(p):
+                                matched_platform = p
+                                matched_group_id = tmp_code_rest[len(p):]
+                                break
+                    if matched_platform:
+                        input_platform = matched_platform
+                        input_group_id = matched_group_id.strip() or str(plugin_event.data.group_id)
+                    else:
+                        input_group_id = tmp_code_rest.strip()
+                        input_platform = plugin_event.platform['platform']
                 else:
                     input_group_id = str(plugin_event.data.group_id)
-                if len(tmp_code_parts) >= 2:
-                    input_platform = tmp_code_parts[1]
-                else:
                     input_platform = plugin_event.platform['platform']
                 # 校验 UUID 对应的日志文件是否存在
                 log_dir = OlivaDiceLogger.data.dataPath + OlivaDiceLogger.data.dataLogPath
@@ -2464,29 +2492,27 @@ def unity_reply(plugin_event, Proc):
                     )
                     replyMsg(plugin_event, tmp_reply_str)
                     return
-                # 校验来源群：遍历该群所有 botHash 条目，须持有该 UUID 的活跃日志
-                old_group_hash = OlivaDiceCore.userConfig.getUserHash(
-                    input_group_id, 'group', input_platform
-                )
-                old_has_uuid = False
-                tmp_user_config_data = OlivaDiceCore.userConfig.dictUserConfigData
-                if old_group_hash in tmp_user_config_data:
-                    for tmp_bot_key in tmp_user_config_data[old_group_hash]:
-                        tmp_entry = tmp_user_config_data[old_group_hash][tmp_bot_key]
-                        tmp_config_note = tmp_entry.get('configNote', {})
-                        if not tmp_config_note.get('logEnable', False):
-                            continue
-                        tmp_name_dict = tmp_config_note.get('logNameDict', {})
-                        if log_uuid in tmp_name_dict.values():
-                            old_has_uuid = True
-                            break
-                if not old_has_uuid:
-                    dictTValue['tLogUUID'] = log_uuid
-                    tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
-                        dictStrCustom['strLoggerLogCodeGroupInvalid'], dictTValue
+                # 校验来源群（end 后缀跳过）
+                if not flag_log_ended:
+                    old_group_hash = OlivaDiceCore.userConfig.getUserHash(
+                        input_group_id, 'group', input_platform
                     )
-                    replyMsg(plugin_event, tmp_reply_str)
-                    return
+                    old_has_uuid = False
+                    tmp_user_config_data = OlivaDiceCore.userConfig.dictUserConfigData
+                    if old_group_hash in tmp_user_config_data:
+                        for tmp_bot_key in tmp_user_config_data[old_group_hash]:
+                            tmp_entry = tmp_user_config_data[old_group_hash][tmp_bot_key]
+                            tmp_name_dict = tmp_entry.get('configNote', {}).get('logNameDict', {})
+                            if log_uuid in tmp_name_dict.values():
+                                old_has_uuid = True
+                                break
+                    if not old_has_uuid:
+                        dictTValue['tLogUUID'] = log_uuid
+                        tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                            dictStrCustom['strLoggerLogCodeGroupInvalid'], dictTValue
+                        )
+                        replyMsg(plugin_event, tmp_reply_str)
+                        return
                 # 懒加载：清理过期码
                 tmp_ttl = OlivaDiceCore.console.getConsoleSwitchByHash(
                     'defaultLogContinueCodeTTL', plugin_event.bot_info.hash

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -576,17 +576,17 @@ def unity_reply(plugin_event, Proc):
                         except Exception:
                             # 如果引用回复失败，抛出异常回复
                             dictTValue['tLogName'] = log_name
-                            tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                            tmp_reply_str_quote_error = OlivaDiceCore.msgCustomManager.formatReplySTR(
                                 dictStrCustom['strLoggerLogQuoteError'], dictTValue
                             )
-                            replyMsg(plugin_event, tmp_reply_str)
+                            replyMsg(plugin_event, tmp_reply_str_quote_error)
                     else:
                         # 其他平台不支持引用回复
                         dictTValue['tLogName'] = log_name
-                        tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        tmp_reply_str_quote_error = OlivaDiceCore.msgCustomManager.formatReplySTR(
                             dictStrCustom['strLoggerLogQuoteError'], dictTValue
                         )
-                        replyMsg(plugin_event, tmp_reply_str)
+                        replyMsg(plugin_event, tmp_reply_str_quote_error)
                 # 正常回复
                 replyMsg(plugin_event, tmp_reply_str)
                 return
@@ -2799,7 +2799,6 @@ def unity_reply(plugin_event, Proc):
                     platform=tmp_pc_platform,
                     userConfigKey='logQuote',
                     botHash=plugin_event.bot_info.hash,
-                    default=False,
                 )
                 if isMatchWordStart(tmp_reast_str, 'on', fullMatch=True):
                     # log quote on 命令
@@ -2938,7 +2937,6 @@ def unity_reply(plugin_event, Proc):
                     platform=tmp_pc_platform,
                     userConfigKey='logUsePcName',
                     botHash=plugin_event.bot_info.hash,
-                    default=False,
                 )
                 if isMatchWordStart(tmp_reast_str, 'on', fullMatch=True):
                     # log pcname on 命令


### PR DESCRIPTION
## Summary by Sourcery

Enhance cross-platform log continuation code generation with flexible platform matching and end-suffix handling, and bump the logger module version.

New Features:
- Support greedy bidirectional matching of platform names attached to the group ID when generating cross-platform continuation codes.
- Allow using an end suffix with UUID to skip group validation and generate continuation codes for already-ended logs.

Enhancements:
- Use tmp_hagID instead of the raw group_id when displaying the current group/channel identifier in .log id output.
- Improve default platform/group handling when platform name cannot be matched or parameters are omitted.
- Clarify logger messages and help text for .log code and .log resume/continue usage, including updated wording around active logs and aliases.

Build:
- Bump OlivaDiceLogger version to 3.0.37 and increment svn revision to 45.