### PR TITLE
feat: 3.0.41 qqGuildV2 支持引用

### DIFF
--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.40",
-    "svn" : 48,
+    "version" : "3.0.41",
+    "svn" : 49,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.40'
-OlivaDiceLogger_svn = 48
+OlivaDiceLogger_ver = '3.0.41'
+OlivaDiceLogger_svn = 49
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -347,6 +347,13 @@ def loggerEntry(event, funcType, sender, dectData, message):
             if not hasattr(event, 'data') or not hasattr(event.data, 'message_id'):
                 return
             message_id = event.data.message_id
+            message_ref_idx = None
+            if event.platform['sdk'] == 'qqGuildv2_link':
+                extend_data = getattr(event.data, 'extend', None)
+                if isinstance(extend_data, dict):
+                    qq_msg_idx = extend_data.get('qq_msg_idx', None)
+                    if qq_msg_idx is not None and str(qq_msg_idx).startswith('REFIDX_'):
+                        message_ref_idx = str(qq_msg_idx)
 
             # 检查是否启用使用角色卡名字功能
             log_use_pc_name = OlivaDiceCore.userConfig.getUserConfigByKey(
@@ -369,6 +376,7 @@ def loggerEntry(event, funcType, sender, dectData, message):
                 'time': int(time.mktime(time.localtime())),
                 'type': funcType,
                 'message_id': message_id,
+                'message_ref_idx': message_ref_idx,
                 'deleted': False,
                 'dect': {
                     'host_id': host_id,
@@ -602,6 +610,24 @@ def get_last_message_id(log_file_path):
         except Exception:
             pass
     return last_message_id
+
+
+def get_last_message_ref_idx(log_file_path):
+    """获取最后一条有效日志的 QQ Guild v2 引用索引。"""
+    last_message_ref_idx = None
+    if os.path.exists(log_file_path):
+        try:
+            with open(log_file_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    try:
+                        log_entry = json.loads(line.strip())
+                        if not log_entry.get('deleted', False) and 'message_id' in log_entry:
+                            last_message_ref_idx = log_entry.get('message_ref_idx', None)
+                    except Exception:
+                        continue
+        except Exception:
+            pass
+    return last_message_ref_idx
 
 
 def write_status_to_file(log_uuid, status_data):

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -55,6 +55,7 @@ def unity_reply(plugin_event, Proc):
     skipSpaceStart = OlivaDiceCore.msgReply.skipSpaceStart
     skipToRight = OlivaDiceCore.msgReply.skipToRight
     msgIsCommand = OlivaDiceCore.msgReply.msgIsCommand
+    flag_qqguild_v2 = plugin_event.platform['sdk'] == 'qqGuildv2_link'
 
     tmp_at_str = OlivOS.messageAPI.PARA.at(plugin_event.base_info['self_id']).CQ()  # NOQA: F841
     tmp_id_str = str(plugin_event.base_info['self_id'])
@@ -307,7 +308,10 @@ def unity_reply(plugin_event, Proc):
                     dataPath = OlivaDiceLogger.data.dataPath
                     dataLogPath = OlivaDiceLogger.data.dataLogPath
                     dataLogFile = f'{dataPath}{dataLogPath}/{tmp_logName}.olivadicelog'
-                    last_message_id = OlivaDiceLogger.logger.get_last_message_id(dataLogFile)
+                    if flag_qqguild_v2:
+                        last_message_id = OlivaDiceLogger.logger.get_last_message_ref_idx(dataLogFile)
+                    else:
+                        last_message_id = OlivaDiceLogger.logger.get_last_message_id(dataLogFile)
 
                 if log_name not in log_name_list:
                     log_name_list.append(log_name)
@@ -562,9 +566,15 @@ def unity_reply(plugin_event, Proc):
                     userConfigKey='logQuote',
                     botHash=plugin_event.bot_info.hash,
                 )
+                if is_continue and flag_qqguild_v2 and not last_message_id and log_quote:
+                    dictTValue['tLogName'] = log_name
+                    tmp_reply_str_quote_error = OlivaDiceCore.msgCustomManager.formatReplySTR(
+                        dictStrCustom['strLoggerLogQuoteError'], dictTValue
+                    )
+                    replyMsg(plugin_event, tmp_reply_str_quote_error)
                 # 如果是继续日志且有最后一个 message_id 并且开启了 log quote，尝试引用回复
                 if is_continue and last_message_id and log_quote:
-                    if plugin_event.platform['platform'] == 'qq':
+                    if plugin_event.platform['platform'] == 'qq' or flag_qqguild_v2:
                         try:
                             # 尝试构造引用回复消息
                             dictTValue['tLogName'] = log_name
@@ -2898,9 +2908,15 @@ def unity_reply(plugin_event, Proc):
                     dataPath = OlivaDiceLogger.data.dataPath
                     dataLogPath = OlivaDiceLogger.data.dataLogPath
                     dataLogFile = f'{dataPath}{dataLogPath}/{tmp_logName}.olivadicelog'
-                    last_message_id = OlivaDiceLogger.logger.get_last_message_id(dataLogFile)
+                    if flag_qqguild_v2:
+                        last_message_id = OlivaDiceLogger.logger.get_last_message_ref_idx(dataLogFile)
+                    else:
+                        last_message_id = OlivaDiceLogger.logger.get_last_message_id(dataLogFile)
                     dictTValue['tLogName'] = log_name
-                    if last_message_id and plugin_event.platform['platform'] == 'qq':
+                    if last_message_id and (
+                        plugin_event.platform['platform'] == 'qq'
+                        or flag_qqguild_v2
+                    ):
                         try:
                             # 尝试构造引用回复消息
                             tmp_reply_str = OlivaDiceCore.msgCustomManager.formatReplySTR(


### PR DESCRIPTION
## Summary by Sourcery

Add QQ Guild v2 log quoting support and update logger metadata.

New Features:
- Store QQ Guild v2 message reference indices in log entries to enable quote-based replies.
- Support continuing logs with quoted replies for QQ Guild v2 sessions, including error feedback when no reference is available.

Enhancements:
- Introduce helper to retrieve the last QQ Guild v2 message reference index from log files.
- Unify quote-reply handling logic between QQ and QQ Guild v2 platforms.

Chores:
- Bump OlivaDiceLogger module version to 3.0.41 and svn to 49.