### PR TITLE
feat: 3.0.43 新增 qqGuildv2 指名适配

### DIFF
--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.41",
-    "svn" : 49,
+    "version" : "3.0.43",
+    "svn" : 51,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.41'
-OlivaDiceLogger_svn = 49
+OlivaDiceLogger_ver = '3.0.43'
+OlivaDiceLogger_svn = 51
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/msgReply.py
+++ b/OlivaDiceLogger/msgReply.py
@@ -65,6 +65,10 @@ def unity_reply(plugin_event, Proc):
         if plugin_event.data.extend['sub_self_id'] is not None:
             tmp_at_str_sub = OlivOS.messageAPI.PARA.at(plugin_event.data.extend['sub_self_id']).CQ()  # NOQA: F841
             tmp_id_str_sub = str(plugin_event.data.extend['sub_self_id'])
+    tmp_id_str_sub_open = None
+    if 'sub_self_open_id' in plugin_event.data.extend:
+        if plugin_event.data.extend['sub_self_open_id'] is not None:
+            tmp_id_str_sub_open = str(plugin_event.data.extend['sub_self_open_id'])
     tmp_command_str_1 = '.'  # NOQA: F841
     tmp_command_str_2 = '。'  # NOQA: F841
     tmp_command_str_3 = '/'  # NOQA: F841
@@ -99,6 +103,8 @@ def unity_reply(plugin_event, Proc):
         if tmp_id_str in tmp_at_list:
             flag_force_reply = True
         if tmp_id_str_sub in tmp_at_list:
+            flag_force_reply = True
+        if tmp_id_str_sub_open in tmp_at_list:
             flag_force_reply = True
         if 'all' in tmp_at_list:
             flag_force_reply = True


### PR DESCRIPTION
## Summary by Sourcery

Add support for QQ Guild v2 open ID mentions in the logger reply handling and bump the OlivaDiceLogger plugin version metadata.

New Features:
- Support recognizing and forcing replies based on sub_self_open_id mentions in QQ Guild v2 events.

Chores:
- Update OlivaDiceLogger version and SVN identifiers in app.json and data.py to 3.0.43/51.