### PR TITLE
fix(logger): 3.0.44 修复日志异常字符崩溃

### DIFF
--- a/OlivaDiceLogger/app.json
+++ b/OlivaDiceLogger/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceLogger",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的日志模块，提供了跑团日志记录器，它可以在跑团过程中对日志进行记录，并由结果生成跑团日志，与在线的跑团日志渲染器进行联动、或发送日志邮件。",
-    "version" : "3.0.43",
-    "svn" : 51,
+    "version" : "3.0.44",
+    "svn" : 52,
     "compatible_svn" : 190,
     "priority" : 20030,
     "support" : [

--- a/OlivaDiceLogger/data.py
+++ b/OlivaDiceLogger/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceLogger_ver = '3.0.43'
-OlivaDiceLogger_svn = 51
+OlivaDiceLogger_ver = '3.0.44'
+OlivaDiceLogger_svn = 52
 OlivaDiceLogger_ver_short = '%s(%s)' % (str(OlivaDiceLogger_ver), str(OlivaDiceLogger_svn))
 
 dataPath = './plugin/data/OlivaDice/unity'

--- a/OlivaDiceLogger/logger.py
+++ b/OlivaDiceLogger/logger.py
@@ -31,6 +31,16 @@ from functools import wraps
 gLoggerIOLockMap = {}
 
 
+def safe_text(value):
+    """只转义孤立 Unicode 代理字符，保持正常文本原样写入。"""
+    if not isinstance(value, str):
+        return value
+    try:
+        return value.encode('utf-8', errors='backslashreplace').decode('utf-8')
+    except Exception:
+        return repr(value)
+
+
 def check_and_process_compatibility():
     # 兼容改为创建文件，只做一次，之后不做
     dataPath = OlivaDiceLogger.data.dataPath
@@ -383,8 +393,8 @@ def loggerEntry(event, funcType, sender, dectData, message):
                     'group_id': group_id,
                     'user_id': user_id,
                 },
-                'sender': {'id': tmp_id, 'name': tmp_name},
-                'message': message,
+                'sender': {'id': tmp_id, 'name': safe_text(tmp_name)},
+                'message': safe_text(message),
             }
             log_str = json.dumps(log_dict, ensure_ascii=False)
             log_name_dict = (


### PR DESCRIPTION
## Summary by Sourcery

Handle abnormal Unicode characters in logged sender names and messages to prevent logger crashes and bump module version metadata.

Bug Fixes:
- Prevent logger crashes caused by invalid or isolated Unicode surrogate characters in logged messages and sender names.

Enhancements:
- Introduce a text sanitization helper to safely record problematic Unicode content while preserving normal text.

Build:
- Update module version and SVN identifiers to 3.0.44/52 in configuration and data metadata.